### PR TITLE
Strict-mode fix

### DIFF
--- a/lib/streaming-api-connection.js
+++ b/lib/streaming-api-connection.js
@@ -98,7 +98,7 @@ StreamingAPIConnection.prototype._startPersistentConnection = function () {
         self.emit('error', error);
         // stop the stream explicitly so we don't reconnect
         self.stop()
-        delete body
+        body = null;
       })
       return
     } else if (self.response.statusCode === 420) {


### PR DESCRIPTION
The twit library can't be used in strict mode due to: http://stackoverflow.com/questions/10643587/motive-behind-strict-mode-syntax-error-when-deleting-an-unqualified-identifier

Removing "delete body" works.